### PR TITLE
Set `tmpl` as global variable

### DIFF
--- a/controller/home_controller.go
+++ b/controller/home_controller.go
@@ -5,7 +5,8 @@ import (
 	"net/http"
 )
 
+var tmpl = template.Must(template.ParseFiles("view/index.html"))
+
 func Index(w http.ResponseWriter, r *http.Request) {
-	tmpl := template.Must(template.ParseFiles("view/index.html"))
 	tmpl.Execute(w, nil)
 }

--- a/controller/home_controller.go
+++ b/controller/home_controller.go
@@ -5,8 +5,8 @@ import (
 	"net/http"
 )
 
-var tmpl = template.Must(template.ParseFiles("view/index.html"))
+var indexTmpl = template.Must(template.ParseFiles("view/index.html"))
 
 func Index(w http.ResponseWriter, r *http.Request) {
-	tmpl.Execute(w, nil)
+	indexTmpl.Execute(w, nil)
 }

--- a/controller/model_controller.go
+++ b/controller/model_controller.go
@@ -8,11 +8,11 @@ import (
 	"github.com/go-chi/chi/v5"
 )
 
-var tmpl = template.Must(template.ParseFiles("view/model/listview.html"))
+var listViewTmpl = template.Must(template.ParseFiles("view/model/listview.html"))
 
 func ListModel(w http.ResponseWriter, r *http.Request) {
 	models := repository.GetModels()
-	tmpl.Execute(w, models)
+	listViewTmpl.Execute(w, models)
 }
 
 func GetModel(w http.ResponseWriter, r *http.Request) {

--- a/controller/model_controller.go
+++ b/controller/model_controller.go
@@ -8,9 +8,10 @@ import (
 	"github.com/go-chi/chi/v5"
 )
 
+var tmpl = template.Must(template.ParseFiles("view/model/listview.html"))
+
 func ListModel(w http.ResponseWriter, r *http.Request) {
 	models := repository.GetModels()
-	tmpl := template.Must(template.ParseFiles("view/model/listview.html"))
 	tmpl.Execute(w, models)
 }
 


### PR DESCRIPTION
Creating `tmpl` variable every time a request comes is expensive. Why not just create the template once (when the application starts) and reuse the same template?